### PR TITLE
Fix error on gandyn.py with python 3.6

### DIFF
--- a/src/gandyn.py
+++ b/src/gandyn.py
@@ -155,7 +155,7 @@ def main(argv, global_vars, local_vars):
 		if current_ip_address != previous_ip_address:
 			# update record value
 			gandi_updater.update_record_value(current_ip_address, TTL)
-			syslog.syslog(syslog.LOG_INFO('DNS updated'))
+			syslog.syslog(syslog.LOG_INFO, 'DNS updated')
 		else:
 			syslog.syslog(syslog.LOG_DEBUG, 'Public IP address unchanged. Nothing to do.')
 		syslog.syslog(syslog.LOG_INFO, "Finished")


### PR DESCRIPTION
I've fix an issue while running with python 3.6.
Error was:
```
gandyn: Started
Traceback (most recent call last):
  File "/usr/bin/gandyn.py", line 168, in <module>
    main(sys.argv, globals(), locals())
  File "/usr/bin/gandyn.py", line 158, in main
    syslog.syslog(syslog.LOG_INFO('DNS updated'))
TypeError: 'int' object is not callable
```